### PR TITLE
feat:Header 공통 컴포넌트 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { ReactNode } from 'react';
+import { Leaf, User } from 'lucide-react';
+
+export default function Header(){
+  return (
+    <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm border-b border-border px-4 py-4 shadow-[var(--shadow-soft)]">
+        <div className="max-w-xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="w-9 h-9 rounded-full bg-primary flex items-center justify-center">
+              <Leaf className="w-5.5 h-5.5 text-primary-foreground" />
+            </div>
+            <h1 className="text-xl font-bold text-primary">Plantiful</h1>
+          </div>
+          <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center">
+            <User className="h-4 w-4" />      
+          </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #41

## 작업 내용
<img width="1359" height="944" alt="Header 작업" src="https://github.com/user-attachments/assets/c6f89617-5f5b-4940-a169-9e0a293a26e1" />

- Header에 Lucide-react를 이용한 Leaf, User 아이콘 적용.
- 상단 고정을 유연하게 하기 위해 sticky 속성 사용.
- 추후 스크롤 시, 뒷배경을 약간 흐릿하게 나마 보일 수 있도록 bg-background/95, blur 속성 적용.
- User 아이콘 부분의 붕 떠있는 느낌을 없애기 위해 bg-gray-100 속성 적용.

## 필수 확인 사항
- npm run dev
- 콘솔 에러
- 주요 페이지 진입 확인
- layout.tsx에 <Header> 삽입 시 작동 확인 (최상단에 import Header from "../components/Header" 삽입 필요.)