### PR TITLE
feat: fab 버튼 추가

### DIFF
--- a/src/components/common/fab-button.tsx
+++ b/src/components/common/fab-button.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React, { ReactNode } from 'react'
+import Button, { ButtonProps } from './button'
+import cn from '../../lib/cn'
+import { Plus } from 'lucide-react'
+
+interface FabProps
+  extends Omit<
+    ButtonProps,
+    'variant' | 'size' | 'as' | 'widthFull' | 'leftIcon' | 'rightIcon' | 'isLoading'
+  > {
+  icon?: ReactNode
+  children?: never
+}
+
+const Fab = React.forwardRef<HTMLButtonElement, FabProps>(({ className, icon, ...props }, ref) => {
+  return (
+    <Button
+      ref={ref}
+      variant="destructive"
+      size="icon"
+      className={cn(
+        'fixed bottom-8 right-8',
+        'h-14 w-14',
+        'rounded-3xl',
+        'shadow-lg',
+        'animate-pulse-glow',
+        'transition-all duration-200 ease-in-out',
+        'hover:shadow-2xl'
+      )}
+      {...props}
+    >
+      {icon || <Plus className="h-6 w-6" strokeWidth={2.5} />}
+    </Button>
+  )
+})
+
+Fab.displayName = 'Fab'
+
+export default Fab


### PR DESCRIPTION
# 관련 이슈
Closes #40 

# 작업내용
* 플로팅 버튼 구현
* 러버블과 디자인 달라진 부분 있음
  * 파동 애니메이션 제겨
  * 모양 변경
  * lucid-react 아이콘 사용

<img width="248" height="192" alt="image" src="https://github.com/user-attachments/assets/d4ff0abc-ab43-4d11-bd8f-9932b657dd63" />


<img width="184" height="178" alt="image" src="https://github.com/user-attachments/assets/161bd150-d2e9-459a-9dba-7aa093b5cc85" />

좌측 러버블 우측 현재 

