### PR TITLE
feat: 메인 페이지 구현

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,0 +1,14 @@
+import Header from "@/components/Header"
+import { ReactNode } from 'react'
+
+export default function HomePage({ children }: { children: ReactNode }) {
+
+  return (
+    <div className="min-h-screen bg-background pb-20">
+      <Header />
+      <main>
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,0 +1,40 @@
+export default function Home() {
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-6 animate-fade-in">
+      {/* 3D 식물 표시 박스 */}
+      <section>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="font-semibold text-foreground">오늘의 식물</h2>
+              <span className="text-sm text-muted-foreground">식물 이름</span>
+            </div>
+            <div className="w-full h-80 border-1 rounded-lg bg-primary/10 grid justify-center items-center">3D 이미지 박스</div>
+      </section>
+      
+      {/* 식물 검색 */}
+      <section className="space-y-3">
+        <div className="relative">
+          <div className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+              placeholder="식물 이름 검색"   
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-foreground">내 식물들</h2>
+          <span className="text-sm text-muted-foreground">물주기 우선</span>
+        </div>
+      </section>
+
+      {/* 내 식물 표기 공간 */}
+      <section>
+        <div className="text-center py-12">
+          <p className="text-muted-foreground mb-4">아직 등록된 식물이 없습니다</p>
+        </div>
+      </section>
+
+      <button className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-float bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+      >+</button>
+    </div>
+    
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #56 

## 스크린샷
<img width="1416" height="962" alt="메인화면 초안" src="https://github.com/user-attachments/assets/251cba23-c551-489c-9e94-a1762ad800b5" />

## 작업 내용
- Layout에 Header 배치 및 page 라우팅
- 초기 메인 페이지 화면 제공

## 필수 확인 사항
- npm run dev
- 콘솔 에러
- 주요 페이지 진입 확인