### PR TITLE
feat: 메인 레이아웃 헤더 배치 수정

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,11 +1,10 @@
-import Header from "@/components/Header"
+
 import { ReactNode } from 'react'
 
 export default function HomePage({ children }: { children: ReactNode }) {
 
   return (
-    <div className="min-h-screen bg-background pb-20">
-      <Header />
+    <div className="min-h-screen bg-background">
       <main>
         {children}
       </main>

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,11 @@
+import Header from "@/components/Header"
+
 export default function Home() {
   return (
+  <>
+  <Header />
     <div className="max-w-xl mx-auto p-4 space-y-6 animate-fade-in">
+      
       {/* 3D 식물 표시 박스 */}
       <section>
             <div className="mb-3 flex items-center justify-between">
@@ -35,6 +40,6 @@ export default function Home() {
       <button className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-float bg-destructive hover:bg-destructive/90 text-destructive-foreground"
       >+</button>
     </div>
-    
+    </>
   );
 }


### PR DESCRIPTION
## 관련 이슈
closes #62

## 작업 내용
- 메인 레이아웃 헤더가 다른 페이지 진입 시에는 안 보이게 수정

## 스크린샷
<img width="880" height="128" alt="헤더 fix" src="https://github.com/user-attachments/assets/baa8ceef-14b4-403e-9e8b-aa30e4ce1e7c" />


## 필수 확인 사항
- npm run dev
- 콘솔 에러
- 주요 페이지 진입 확인