### PR TITLE
perf: 중복 인증 제거 및 마이페이지 prefetch 비활성화

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -50,9 +50,11 @@ export const config = {
      * Match all request paths except for the ones starting with:
      * - _next/static (static files)
      * - _next/image (image optimization files)
+     * - _next/data (prefetch data requests)
+     * - apis (API routes - 자체 인증 처리)
      * - favicon.ico (favicon file)
      * - public files (public folder)
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|_next/data|apis/|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -8,27 +8,22 @@ import type { Plant } from '@/types/plant'
 
 export default async function Home() {
   const queryClient = new QueryClient()
+  const supabase = await createClient()
+
+  // Middleware가 인증을 보장하므로 user는 항상 존재 user.id를 얻기 위해 getUser() 호출
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
   // 서버에서 식물 목록 prefetch
   await queryClient.prefetchQuery({
     queryKey: queryKeys.plants.list(),
     queryFn: async (): Promise<Plant[]> => {
-      const supabase = await createClient()
-
-      // 인증 확인
-      const {
-        data: { user },
-      } = await supabase.auth.getUser()
-
-      if (!user) {
-        return []
-      }
-
       // 식물 목록 조회
       const { data, error } = await supabase
         .from('plants')
         .select('*')
-        .eq('user_id', user.id)
+        .eq('user_id', user!.id)
         .order('created_at', { ascending: false })
 
       if (error) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
           </div>
           <h1 className="text-xl font-bold text-primary">Plantiful</h1>
         </div>
-        <Link href="/mypage">
+        <Link href="/mypage" prefetch={false}>
           <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center">
             <User className="h-4 w-4" />
           </div>


### PR DESCRIPTION
## 작업 내용
- Header에서 Link mypage prefetch false 처리
- 미들웨어 Matcher 최적화: API routes는 자체적으로 인증 처리하여 제외
- 메인 페이지 prefetchQuery에서 중복 인증 체크 제거 (미들웨어에서 이미 인증)