### PR TITLE
feat: 비밀번호 변경 기능 구현

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader } from '@/components/common/card'
 import Button from '@/components/common/button'
 import Input from '@/components/common/Input'
 import LogoutButton from '@/components/auth/LogoutButton'
+import UpdatePasswordForm from '@/components/auth/UpdatePasswordForm'
 
 export default function Page() {
   const [nickname, setNickname] = useState('식집사')
@@ -72,54 +73,7 @@ export default function Page() {
             </div>
           </CardHeader>
           <CardContent className="pt-0 space-y-4">
-            <div className="space-y-2">
-              <label
-                htmlFor="current-password"
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                현재 비밀번호
-              </label>
-              <Input
-                size="sm"
-                id="current-password"
-                type="password"
-                placeholder="••••••••"
-                className="mt-2"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="new-password"
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                새 비밀번호
-              </label>
-              <Input
-                size="sm"
-                id="new-password"
-                type="password"
-                placeholder="••••••••"
-                className="mt-2"
-              />
-            </div>
-            <div className="space-y-2">
-              <label
-                htmlFor="confirm-password"
-                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                새 비밀번호 확인
-              </label>
-              <Input
-                size="sm"
-                id="confirm-password"
-                type="password"
-                placeholder="••••••••"
-                className="mt-2"
-              />
-            </div>
-            <Button variant="default" className="w-full bg-primary hover:bg-primary/90">
-              비밀번호 변경
-            </Button>
+            <UpdatePasswordForm />
           </CardContent>
         </Card>
         <div className="my-6" />

--- a/src/app/actions/auth/updatePassword.ts
+++ b/src/app/actions/auth/updatePassword.ts
@@ -1,0 +1,52 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+
+export async function updatePassword(formData: FormData) {
+  const newPassword = formData.get('newPassword')?.toString()
+  const currentPassword = formData.get('currentPassword')?.toString()
+  const confirmPassword = formData.get('confirmPassword')?.toString()
+
+  // 비밀번호 양식
+  const validatePassword = (password: string) => {
+    const regex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d!@#$%^&*]{8,}$/
+    return regex.test(password)
+  }
+
+  // 값 입력 검증
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    return { error: '모든 항목을 입력해주세요.' }
+  }
+  // 유효성 검증
+  if (!validatePassword(newPassword)) {
+    return { error: '비밀번호는 8자 이상이며, 영문과 숫자를 포함해야 합니다.'}
+  }
+  // 비밀번호 확인 일치 여부 검증
+  if (newPassword !== confirmPassword) {
+    return { error: '설정할 비밀번호가 일치하지 않습니다.' }
+  }
+
+  const supabase = await createClient()
+  const user = (await supabase.auth.getUser()).data.user
+  if (!user?.email) return { error: '사용자 정보를 불러 오지 못했습니다.' }
+  // 현재 비밀번호가 일치하는 지 검증
+  const {
+    error: signInError
+  } = await supabase.auth.signInWithPassword({
+    email: (await supabase.auth.getUser()).data.user?.email!,
+    password: currentPassword,
+  })
+
+  if (signInError) return { error: '현재 비밀번호가 올바르지 않습니다.' }
+  
+  if (newPassword === currentPassword) return { error: '이전 비밀번호는 사용하실 수 없습니다.' }
+
+  // 비밀번호 변경
+  const { error } = await supabase.auth.updateUser({
+    password: newPassword,
+  })
+
+  if (error) return { error: "비밀번호가 변경되지 않았습니다." }
+
+  return { success: '비밀번호가 성공적으로 변경되었습니다.'  }
+}

--- a/src/components/auth/UpdatePasswordForm.tsx
+++ b/src/components/auth/UpdatePasswordForm.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { updatePassword } from '@/app/actions/auth/updatePassword'
+import { useState, useTransition } from 'react'
+import Button from '@/components/common/button'
+import Input from '@/components/common/Input'
+
+export default function UpdatePasswordForm() {
+  const [msg, setMsg] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData();
+    formData.set('currentPassword', currentPassword)
+    formData.set('newPassword', newPassword)
+    formData.set('confirmPassword', confirmPassword)
+  
+    // 서버 응답 중 UI 깜빡임 방지를 위해 useTransition 사용.
+    startTransition(async () => {
+      const result = await updatePassword(formData)
+
+      // 에러 발생 시, 에러 메세지 출력
+      if (result.error) {
+        setMsg(result.error)
+      }
+      // 성공 시, 변경 완료 문구 출력
+      else if (result.success) {
+        setMsg(result.success)
+        setTimeout(() => setMsg(null), 3000) // 3초 뒤 메시지 사라짐
+        
+        // 입력칸 초기화
+        setCurrentPassword('')
+        setNewPassword('')
+        setConfirmPassword('')
+      }
+    })
+  }
+
+  return (            
+  <form onSubmit={handleSubmit} className="space-y-4">
+    <div className="space-y-2">
+      <label
+        htmlFor="currentPassword"
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >현재 비밀번호
+      </label>
+      <Input
+        size="sm"
+        id="currentPassword"
+        /* name="currentPassword" // 기본 폼일때 사용 가능 */
+        type="password"
+        placeholder="••••••••"
+        className="mt-2"
+        value={currentPassword}
+        onChange={(e) => setCurrentPassword(e.target.value)}
+      />
+    </div>
+    <div className="space-y-2">
+      <label
+        htmlFor="newPassword"
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >새 비밀번호
+      </label>
+      <Input
+        size="sm"
+        id="newPassword"
+        /* name="newPassword" // 기본 폼일때 사용 가능 */
+        type="password"
+        placeholder="••••••••"
+        className="mt-2"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+      />
+    </div>
+    <div className="space-y-2">
+      <label
+        htmlFor="confirmPassword"
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >새 비밀번호 확인
+      </label>
+      <Input
+        size="sm"
+        id="confirmPassword"
+        /* name="confirmPassword" // 기본 폼일때 사용 가능 */
+        type="password"
+        placeholder="••••••••"
+        className="mt-2"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+      />
+    </div>
+    <Button 
+      variant="default"
+      className="w-full bg-primary hover:bg-primary/90"
+      type="submit"
+      disabled={isPending}
+    >{isPending ? '변경 중...' : '비밀번호 변경'}                
+    </Button>
+    {msg && (
+      <p className={`mt-2 text-sm ${msg.includes('성공') ? 'text-green-600' : 'text-red-600'}`}>
+        {msg}
+      </p>
+    )}
+  </form>)
+}


### PR DESCRIPTION
## 관련 이슈
closes #15 

## 작업 내용
- 계정 비밀번호 변경 기능 구현
- 비밀번호 변경 폼 컴포넌트 분리

## 스크린샷
<img width="300" height="400" alt="비밀번호 변경 성공" src="https://github.com/user-attachments/assets/c2cd8e9f-d5d3-4dd1-8543-8a178331776c" />
<img width="300" height="400" alt="비밀번호 변경 실패" src="https://github.com/user-attachments/assets/229e6e0a-902a-431a-959e-a0f8fbe8ccff" />


## 필수 확인 사항
- npm run dev
- 콘솔 에러
- 주요 페이지 진입 확인
- 비밀번호 변경 적용 여부 확인