### PR TITLE
feat: 닉네임 변경 기능 구현

### DIFF
--- a/src/app/actions/auth/updateProfiles.ts
+++ b/src/app/actions/auth/updateProfiles.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+
+
+export default async function updateProfiles(formData: FormData) {
+  const newUserName = formData.get('userName')?.toString()
+  const supabase = await createClient()
+
+  // 로그인 유저 확인
+  const { data: { user }, error: userError } = await supabase.auth.getUser()
+
+  if (!user || userError) {
+    return { error: '사용자 정보를 불러오지 못했습니다.' }
+  }
+
+  // DB 업데이트
+  const { error } = await supabase
+    .from('profiles')
+    .update({ name: newUserName })
+    .eq('id', user.id)
+
+  if (error) {
+    return { error: '닉네임 변경에 실패하였습니다.' }
+  }
+
+  return { success: '닉네임이 성공적으로 변경되었습니다.' }
+}

--- a/src/components/auth/UpdateProfileForm.tsx
+++ b/src/components/auth/UpdateProfileForm.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Button from '@/components/common/button'
+import Input from '@/components/common/Input'
+import updateProfiles from '@/app/actions/auth/updateProfiles'
+
+type Props = {
+  initialUserName: string
+}
+
+export default function UpdateProfilesForm({ initialUserName }: Props) {
+  const [msg, setMsg] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [userName, setUserName] = useState(initialUserName)
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    // 닉네임 칸이 비어있을 경우 기본으로 식집사 적용.
+    const isUserName = userName.trim() === '' ? '식집사' : userName.trim()
+    const formData = new FormData()
+    formData.set('userName', isUserName)
+
+    // 서버 응답 중 UI 깜빡임 방지를 위해 useTransition 사용.
+    startTransition(async () => {
+      const result = await updateProfiles(formData)
+
+      // 에러 발생 시, 에러 메세지 출력
+      if (result.error) {
+        setMsg(result.error)
+      }
+      // 성공 시, 변경 완료 문구 출력 
+      else if (result.success) {
+        setMsg(result.success)
+        setTimeout(() => setMsg(null), 3000) // 3초 뒤 메시지 사라짐
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <label
+          htmlFor="userName"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          닉네임
+        </label>
+        <div className="pt-2 flex gap-2">
+          <div className="flex-1">
+            <Input
+              size="sm"
+              id="userName"
+              /* name="userName" // 기본 폼일때 사용 가능 */
+              placeholder="식집사"
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+            />
+          </div>
+          <Button
+            variant="default"
+            size="sm"
+            className="bg-primary hover:bg-primary/90"
+            type="submit"
+            disabled={isPending}
+          >
+            {isPending ? '저장 중...' : '저장'}
+          </Button>
+        </div>
+        {msg && (
+        <p className={`text-sm ${msg.includes('성공') ? 'text-green-600' : 'text-red-600'}`}>
+          {msg}
+        </p>
+        )}
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## 관련 이슈
closes #16 

## 작업 내용
- 마이페이지 진입 시, DB에서 현재 닉네임 불러오기 기능
- 마이페이지 진입 시, 비로그인 상태면 로그인 화면으로 이동
- RLS 작업(불러오기 및 변경 가능)
- 서버 액션으로 DB에 닉네임 변경 요청
- 닉네임 변경 컴포넌트 분리
- 마이페이지 서버 컴포넌트화

## 스크린샷
<img width="570" height="688" alt="닉네임 변경 성공" src="https://github.com/user-attachments/assets/df2b5275-3a54-44ab-a110-7a615f310592" />


## 필수 확인 사항
- 닉네임 변경 여부 적용 확인
- 콘솔 에러 여부 확인
- 주요 페이지 진입 확인