### PR TITLE
hotfix: 브라우저 경고

### DIFF
--- a/src/components/home/PlantModel.tsx
+++ b/src/components/home/PlantModel.tsx
@@ -24,7 +24,11 @@ export default function PlantModel() {
       <Suspense fallback={null}>
         <Model />
       </Suspense>
-      <OrbitControls enableZoom={false} />
+      <OrbitControls
+        enableZoom={false}
+        enablePan={false}
+        makeDefault
+      />
     </Canvas>
   )
 }


### PR DESCRIPTION
## 작업 내용
- OrbitControls의 wheel 이벤트 리스너 등록으로 스크롤을 즉시 처리하지 못하여 브라우저 경고 발생
- 회전만 가능하도록 wheel 사용하는 기능 모두 비활성화
- 해결 불가..
