### PR TITLE
fix: 등록 모달 콘솔 에러 해결

### DIFF
--- a/src/components/plant/register/PlantRegisterContent.tsx
+++ b/src/components/plant/register/PlantRegisterContent.tsx
@@ -13,6 +13,7 @@ import { generateDayOptions, generateMonthOptions } from '@/utils/date'
 import { useAddPlant } from '@/hooks/mutations/useAddPlant'
 import { useGetPlants } from '@/hooks/queries/useGetPlants'
 import cn from '@/lib/cn'
+import { useEffect } from 'react'
 
 interface FormData {
   nickname: string
@@ -62,9 +63,11 @@ export default function PlantRegisterContent({
   })
 
   // isDirty 변경 시 부모에게 알림
-  if (onDirtyChange) {
-    onDirtyChange(isDirty)
-  }
+  useEffect(() => {
+    if (onDirtyChange) {
+      onDirtyChange(isDirty)
+    }
+  }, [isDirty, onDirtyChange])
 
   const onSubmit = handleSubmit((data) => {
     const plantData: PlantData = {


### PR DESCRIPTION
## 작업 내용
- `Cannot update a component (`PlantRegisterModal`) while rendering a different component`
- 자식 컴포넌트 렌더링 중 직접적으로 부모 컴포넌트의 상태를 변경하려고 해서 에러 발생
- useEffect 사용