### PR TITLE
refactor: 검색/정렬 서버 필터링 적용

### DIFF
--- a/src/app/apis/plants/route.ts
+++ b/src/app/apis/plants/route.ts
@@ -1,24 +1,72 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { requireAuth } from '@/utils/supabase/helpers'
 import { fromDbFormat } from '@/utils/plant'
+import { normalizeSearch, isChosungOnly } from '@/utils/normalizeSearch'
+import { addDays } from '@/utils/date'
+import type { Plant } from '@/types/plant'
 
 const TABLE_NAME = 'plants'
+type SortKey = 'water' | 'name' | 'recent'
 
 // GET /apis/plants - 식물 목록 조회
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url)
+    const rawQ = (searchParams.get('q') ?? '').trim()
+    const sortParam = (searchParams.get('sort') as SortKey | null) ?? 'recent'
+    const sort: SortKey = sortParam
+
+    // 검색어 정규화
+    const { original: searchWord } = normalizeSearch(rawQ)
+    const useChosungSearch = isChosungOnly(searchWord)
+
     const { user, supabase } = await requireAuth()
 
-    // 식물 목록 조회
-    const { data, error } = await supabase
-      .from(TABLE_NAME)
-      .select('*')
-      .eq('user_id', user.id)
-      .order('created_at', { ascending: false })
+    let query = supabase.from(TABLE_NAME).select('*').eq('user_id', user.id)
 
+    if (searchWord && !useChosungSearch) {
+      query = query.or(
+        `nickname.ilike.%${searchWord}%,korean_name.ilike.%${searchWord}%,scientific_name.ilike.%${searchWord}%`
+      )
+    }
+
+    // 기본 정렬
+    if (sort === 'recent') {
+      query = query.order('created_at', { ascending: false })
+    }
+
+    const { data, error } = await query
     if (error) throw error
 
-    const plants = data.map(fromDbFormat)
+    const rawPlants = (data ?? []).map(fromDbFormat) as Plant[]
+
+    let plants = rawPlants
+    //추가 정렬
+    if (sort === 'name') {
+      plants.sort((a, b) => a.nickname.localeCompare(b.nickname))
+    } else if (sort === 'water') {
+      plants.sort((a, b) => {
+        // 1) A의 다음 물주기 날짜 계산
+        const nextA =
+          a.nextWateringDate ??
+          (a.lastWateredAt && a.wateringIntervalDays
+            ? addDays(a.lastWateredAt, a.wateringIntervalDays)
+            : null)
+
+        // 2) B의 다음 물주기 날짜 계산
+        const nextB =
+          b.nextWateringDate ??
+          (b.lastWateredAt && b.wateringIntervalDays
+            ? addDays(b.lastWateredAt, b.wateringIntervalDays)
+            : null)
+
+        // 3) 숫자 비교를 위해 timestamp로 변환 (없으면 Infinity → 맨 뒤)
+        const aTime = nextA ? new Date(nextA).getTime() : Number.POSITIVE_INFINITY
+        const bTime = nextB ? new Date(nextB).getTime() : Number.POSITIVE_INFINITY
+
+        return aTime - bTime
+      })
+    }
 
     return NextResponse.json({ plants })
   } catch (error) {

--- a/src/components/home/PlantListSection.tsx
+++ b/src/components/home/PlantListSection.tsx
@@ -33,44 +33,20 @@ export default function PlantListSection({
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const sortedPlants = useMemo(() => {
-    // 1. 검색 필터링 (완성형 + 초성 둘 다 지원)
-    const { original: searchWord, chosung: searchCho } = normalizeSearch(search)
+    const { original: searchWord } = normalizeSearch(search)
     const useChosungSearch = isChosungOnly(searchWord)
 
-    let filtered = plants
-
-    if (searchWord) {
-      filtered = plants.filter((plant) => {
+    //초성 검색일 때만 클라이언트에서 추가 필터링
+    if (searchWord && useChosungSearch) {
+      return plants.filter((plant) => {
         const nickname = plant.nickname ?? ''
         const { original: nickWord, chosung: nickCho } = normalizeSearch(nickname)
-
         if (!nickWord) return false
-
-        if (useChosungSearch) {
-          return nickCho.includes(searchWord)
-        }
-
-        return nickWord.includes(searchWord)
+        return nickCho.includes(searchWord)
       })
     }
-
-    // 2. 정렬
-    if (sort === 'name') {
-      return [...filtered].sort((a, b) => a.nickname.localeCompare(b.nickname))
-    }
-    if (sort === 'recent') {
-      return [...filtered].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      )
-    }
-
-    // 물주기 우선 정렬
-    return [...filtered].sort((a, b) => {
-      const ddayA = a.nextWateringDate ? calculateDday(a.nextWateringDate) : Infinity
-      const ddayB = b.nextWateringDate ? calculateDday(b.nextWateringDate) : Infinity
-      return ddayA - ddayB
-    })
-  }, [plants, sort, search])
+    return plants
+  }, [plants, search])
 
   const selected = useMemo(
     () => plants.find((p) => p.id === selectedId) ?? null,

--- a/src/hooks/queries/useGetPlants.ts
+++ b/src/hooks/queries/useGetPlants.ts
@@ -2,11 +2,29 @@ import { useQuery } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/queryKeys'
 import type { Plant } from '@/types/plant'
 
-export const useGetPlants = () => {
+export type SortKey = 'water' | 'name' | 'recent'
+
+interface UseGetPlantsParams {
+  search?: string
+  sort?: SortKey
+}
+
+export const useGetPlants = (params: UseGetPlantsParams = {}) => {
+  const { search = '', sort = 'recent' } = params
+
   return useQuery<Plant[], Error>({
-    queryKey: queryKeys.plants.list(),
+    queryKey: [...queryKeys.plants.list(), { search, sort }],
     queryFn: async () => {
-      const response = await fetch('/apis/plants', {
+      const sp = new URLSearchParams()
+
+      const trimmed = search.trim()
+      if (trimmed) sp.set('q', trimmed)
+      if (sort && sort !== 'recent') sp.set('sort', sort)
+
+      const qs = sp.toString()
+      const url = qs ? `/apis/plants?${qs}` : '/apis/plants'
+
+      const response = await fetch(url, {
         credentials: 'include',
       })
 


### PR DESCRIPTION
## 변경 사항
- 목록 필터 상태를 쿼리 파라미터로 서버에 전달하도록 수정
  - 기존: 전체 목록을 가져온 뒤 클라이언트에서 필터링
  - 변경: 서버에서 조건에 맞게 필터링된 결과만 반환
