### PR TITLE
fix: 카드 이미지 불러오기 이슈 해결

### DIFF
--- a/src/app/actions/plant/addPlantAction.ts
+++ b/src/app/actions/plant/addPlantAction.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '@/utils/supabase/helpers'
 import { toDbFormat, fromDbFormat, prepareCardForInsert } from '@/utils/plant'
 import { revalidatePath } from 'next/cache'
 import type { Plant } from '@/types/plant'
+import saveDefaultImage from '@/utils/saveDefaultImage'
 
 const TABLE_NAME = 'plants'
 const STORAGE_BUCKET = 'plant-images'
@@ -23,8 +24,8 @@ export default async function addPlantAction(formData: FormData): Promise<Plant>
       startDate: new Date(parsedData.startDate),
     }
 
-    // 이미지 업로드 처리
-    let coverImageUrl = plantData.image
+    // 1. 사용자 업로드 이미지 처리
+    let coverImageUrl = null
     if (file) {
       // 파일 업로드
       const fileExt = file.name?.split('.').pop()
@@ -47,8 +48,25 @@ export default async function addPlantAction(formData: FormData): Promise<Plant>
       coverImageUrl = publicUrl
     }
 
-    // 데이터 준비
-    const plantToInsert = prepareCardForInsert({ ...plantData, image: coverImageUrl }, user.id)
+    // 2. 농사로 API 기본 이미지를 Storage에 저장
+    let defaultImageUrl = plantData.species.imageUrl
+    if (defaultImageUrl) {
+      const savedUrl = await saveDefaultImage(plantData.species.cntntsNo, defaultImageUrl, supabase)
+      defaultImageUrl = savedUrl || defaultImageUrl // 실패 시 원본 URL 사용
+    }
+
+    // 3. 데이터 준비
+    const plantToInsert = prepareCardForInsert(
+      {
+        ...plantData,
+        species: {
+          ...plantData.species,
+          imageUrl: defaultImageUrl,
+        },
+        image: coverImageUrl,
+      },
+      user.id
+    )
     const dbPlant = toDbFormat(plantToInsert)
 
     // DB 삽입

--- a/src/app/apis/plantDetail/[cntntsNo]/route.ts
+++ b/src/app/apis/plantDetail/[cntntsNo]/route.ts
@@ -67,7 +67,6 @@ export async function GET(
     })
 
     const rawDetail = await getNongsaroDetail(cntntsNo, NONGSARO_API_KEY, parser)
-    console.log('rawDetail =', rawDetail)
 
     if (!rawDetail) {
       return NextResponse.json({ error: '상세 정보를 찾을 수 없습니다.' }, { status: 404 })

--- a/src/hooks/mutations/useAddPlant.ts
+++ b/src/hooks/mutations/useAddPlant.ts
@@ -3,15 +3,10 @@ import { queryKeys } from '@/lib/queryKeys'
 import type { PlantData, Plant } from '@/types/plant'
 import addPlantAction from '@/app/actions/plant/addPlantAction'
 
-interface MutationContext {
-  previousPlants?: Plant[]
-  tempImageUrl?: string
-}
-
 export const useAddPlant = () => {
   const queryClient = useQueryClient()
 
-  return useMutation<Plant, Error, PlantData, MutationContext>({
+  return useMutation<Plant, Error, PlantData>({
     mutationFn: async (plantData: PlantData) => {
       const formData = new FormData()
 
@@ -32,100 +27,8 @@ export const useAddPlant = () => {
       // Server Action 호출
       return await addPlantAction(formData)
     },
-    onMutate: async (newPlant) => {
-      // 진행 중인 리페치 취소
-      await queryClient.cancelQueries({ queryKey: queryKeys.plants.list() })
-
-      // 이전 데이터 백업
-      const previousPlants = queryClient.getQueryData<Plant[]>(queryKeys.plants.list())
-
-      // 임시 이미지 URL 생성 (사용자가 업로드한 파일)
-      const tempImageUrl = newPlant.uploadedImage
-        ? URL.createObjectURL(newPlant.uploadedImage)
-        : newPlant.image || ''
-
-      // 임시 Plant 객체 생성
-      const tempPlant: Plant = {
-        id: 'temp-' + Date.now(),
-        userId: 'temp',
-        cntntsNo: newPlant.species.cntntsNo,
-        koreanName: newPlant.species.koreanName,
-        scientificName: newPlant.species.scientificName || null,
-        defaultImageUrl: newPlant.image || null,
-        coverImageUrl: tempImageUrl,
-        nickname: newPlant.nickname || newPlant.species.koreanName,
-        wateringIntervalDays: newPlant.wateringInterval,
-        fertilizerIntervalDays: newPlant.fertilizerInterval,
-        repottingIntervalDays: newPlant.repottingInterval,
-        adoptedAt: newPlant.startDate.toISOString(),
-        lastWateredAt: newPlant.lastWateredDate.toISOString(),
-        nextWateringDate: new Date(
-          newPlant.lastWateredDate.getTime() + newPlant.wateringInterval * 24 * 60 * 60 * 1000
-        ).toISOString(),
-        lightDemandCode: newPlant.species.careInfo?.lightDemandCode || null,
-        waterCycleCode: newPlant.species.careInfo?.waterCycleCode || null,
-        temperatureCode: newPlant.species.careInfo?.temperatureCode || null,
-        humidityCode: newPlant.species.careInfo?.humidityCode || null,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      }
-
-      // 임시 데이터 즉시 추가 (최신 등록순이므로 맨 앞에)
-      queryClient.setQueryData<Plant[]>(queryKeys.plants.list(), (old = []) => [tempPlant, ...old])
-
-      // 롤백을 위해 이전 데이터 반환
-      return { previousPlants, tempImageUrl }
-    },
-    onError: (_err, _newPlant, context) => {
-      // 실패 시 이전 상태로 롤백
-      if (context?.previousPlants) {
-        queryClient.setQueryData(queryKeys.plants.list(), context.previousPlants)
-      }
-      // 임시 이미지 URL 정리
-      if (context?.tempImageUrl && context.tempImageUrl.startsWith('blob:')) {
-        URL.revokeObjectURL(context.tempImageUrl)
-      }
-    },
-    onSuccess: (data, _variables, context) => {
-      // 1단계: 먼저 blob URL 유지하면서 ID 업데이트 (즉시 반응)
-      queryClient.setQueryData<Plant[]>(queryKeys.plants.list(), (old = []) => {
-        return old.map((plant) => {
-          if (plant.id.startsWith('temp-')) {
-            return {
-              ...data,
-              coverImageUrl: plant.coverImageUrl, // blob URL 유지
-            }
-          }
-          return plant
-        })
-      })
-
-      // 2단계: 서버 이미지가 있으면 preload 후 교체
-      if (data.coverImageUrl && context?.tempImageUrl) {
-        const img = new Image()
-        img.onload = () => {
-          // 이미지 캐시 완료 후 서버 URL로 교체
-          setTimeout(() => {
-            queryClient.setQueryData<Plant[]>(queryKeys.plants.list(), (old = []) => {
-              return old.map((plant) => {
-                if (plant.id === data.id) {
-                  return data
-                }
-                return plant
-              })
-            })
-
-            // blob URL 정리
-            if (context?.tempImageUrl?.startsWith('blob:')) {
-              URL.revokeObjectURL(context.tempImageUrl)
-            }
-          }, 500)
-        }
-        img.src = data.coverImageUrl
-      }
-    },
     onSettled: () => {
-      // 성공/실패 관계없이 서버와 동기화
+      // 성공/실패 관계없이 서버 데이터 새로고침
       queryClient.invalidateQueries({ queryKey: queryKeys.plants.list() })
     },
   })

--- a/src/utils/saveDefaultImage.ts
+++ b/src/utils/saveDefaultImage.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const STORAGE_BUCKET = 'plant-images'
+const DEFAULT_IMAGES_FOLDER = 'default-images'
+
+/**
+ * 농사로 API 이미지를 Storage에 저장 (중복 방지)
+ * - 같은 cntntsNo의 이미지가 이미 존재하면 기존 URL 반환
+ * - 없으면 다운로드 후 업로드하여 URL 반환
+ *
+ * @param cntntsNo - 식물 종류 ID
+ * @param imageUrl - 농사로 API 이미지 URL
+ * @param supabase - Supabase 클라이언트
+ * @returns Storage Public URL 또는 null (실패 시)
+ */
+export default async function saveDefaultImage(
+  cntntsNo: string,
+  imageUrl: string,
+  supabase: SupabaseClient
+): Promise<string | null> {
+  try {
+    // 1. 파일 확장자 추출
+    const urlObj = new URL(imageUrl)
+    const pathname = urlObj.pathname
+    const ext = pathname.split('.').pop() || 'jpg'
+    const fileName = `${DEFAULT_IMAGES_FOLDER}/${cntntsNo}.${ext}`
+
+    // 2. 이미 존재하는지 확인
+    const { data: existingFiles } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .list(DEFAULT_IMAGES_FOLDER, {
+        search: `${cntntsNo}.`,
+      })
+
+    // 3. 이미 존재하면 기존 URL 반환
+    if (existingFiles && existingFiles.length > 0) {
+      const existingFileName = `${DEFAULT_IMAGES_FOLDER}/${existingFiles[0].name}`
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(existingFileName)
+      return publicUrl
+    }
+
+    // 4. 이미지 다운로드
+    const response = await fetch(imageUrl)
+    if (!response.ok) {
+      console.error(`이미지 다운로드 실패: ${imageUrl}`)
+      return null
+    }
+
+    const blob = await response.blob()
+
+    // 5. Storage에 업로드
+    const { data: uploadData, error: uploadError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .upload(fileName, blob, {
+        cacheControl: '31536000', // 1년 캐시
+        upsert: false,
+        contentType: blob.type,
+      })
+
+    if (uploadError) {
+      console.error('이미지 업로드 실패:', uploadError)
+      return null
+    }
+
+    // 6. Public URL 반환
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(uploadData.path)
+
+    return publicUrl
+  } catch (error) {
+    console.error('saveDefaultImage 오류:', error)
+    return null
+  }
+}


### PR DESCRIPTION
## 작업 내용
- 외부 API URL 의존성 문제로 캐시가 지워지면 이미지 로드 실패, alt 텍스트만 표시됨
- 농사로 API 이미지도 Storage에 저장하여 로드하도록 변경
- cntntsNo 기반으로 저장되도록 하여 같은 종류의 식물 이미지는 한 번만 저장하고 가져올 수 있도록 처리
- Storage RLS 정책 수정
  - 기존: 사용자별 폴더에만 이미지 저장 허용
  - 수정: default-images(public) 폴더에도 이미지 저장 및 가져올 수 있도록 수정
- 등록 시 낙관적 업데이트 로직 제거
  - 기존 로직으로는 농사로 API 이미지는 낙관적 업데이트가 되지 않음
  - Next Image에 대해 더 알아보고 추후 재적용할 예정 

## 스크린샷
<img width="784" height="518" alt="image" src="https://github.com/user-attachments/assets/523acb7e-1dae-4c3f-9a26-a65970a36899" />
 